### PR TITLE
L1M4-Jeopardy-Sound-Update

### DIFF
--- a/Level1-Module4/src/_03_jeopardy/Jeopardy.java
+++ b/Level1-Module4/src/_03_jeopardy/Jeopardy.java
@@ -7,7 +7,6 @@ package _03_jeopardy;
  */
 
 
-import java.applet.AudioClip;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -15,13 +14,15 @@ import java.awt.GridLayout;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.File;
 import java.net.URL;
 
-
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.Clip;
 import javax.swing.BoxLayout;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
-import javax.swing.JApplet;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -39,7 +40,7 @@ public class Jeopardy implements ActionListener {
 	private int score = 0;
 	private JLabel scoreBox = new JLabel("0");
 	private int buttonCount = 0;
-	private AudioClip sound;
+	
 
 
 
@@ -148,15 +149,23 @@ public class Jeopardy implements ActionListener {
 
 	}
 
-	public void playJeopardyTheme() {
-		try {
-			sound = JApplet.newAudioClip(getClass().getResource("jeopardy.wav"));
-			sound.play();
-			Thread.sleep(3400);
-		} catch (Exception ex) {
-			ex.printStackTrace();
-		}
-	}
+	public static synchronized void playJeopardyTheme()
+	    {
+		String fileName = "jeopardy.wav";
+	        // Note: use .wav files            
+	        new Thread(new Runnable() {
+	            public void run() {
+	                try {
+	                    Clip clip = AudioSystem.getClip();
+	                    AudioInputStream inputStream = AudioSystem.getAudioInputStream(new File(fileName));
+	                    clip.open(inputStream);
+	                    clip.start();
+	                } catch (Exception e) {
+	                    System.out.println("play sound error: " + e.getMessage() + " for " + fileName);
+	                }
+	            }
+	        }).start();
+	    }
 
 	private Component makeScorePanel() {
 		JPanel panel = new JPanel();


### PR DESCRIPTION
JApplet is deprecated and no longer works in newer JDKs. AudioSystem was the way I found to play sounds in native Java.
(It only works with .wav, .au, .aif, and a few others; not .mp3 or .flac though)